### PR TITLE
A Vagrant configuration for NCSA's nebula OpenStack cloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Vagrant
+.vagrant
+
+# emacs
+*~

--- a/README.md
+++ b/README.md
@@ -6,11 +6,10 @@ A vagrant configuration backed by NCSA's nebula.
 Using vagrant
 -------------
 
-Clone this repo. Get your LSST-openrc.sh from [nebula horizon](https://nebula.ncsa.illinois.edu/dashboard/auth/login/?next=/dashboard/)
+Clone this repo. Get your LSST-openrc.sh from [nebula horizon](https://nebula.ncsa.illinois.edu/dashboard/auth/login/?next=/dashboard/) and source it. Run `vagrant up --provider=openstack` command.
 
 ```bash
 source /path/to/LSST-openrc.sh
 # ... put in nebula password
-cd vagrant-nebula
 vagrant up --provider=openstack
 ```

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ By default this Vagrant configuration provides stable [LSST Software Stack](http
 Internals
 ---------
 
-Your Vagrant machine is provisioned on Nebula's OpenStack cloud through the OpenStack API. Your machine will be named `el7-user` where user is your username when you run the `vagrant` command. The [vagrant-openstack-provider](https://github.com/ggiamarchi/vagrant-openstack-provider) will create and associate an SSH key-pair for your Vagrant machine. If you log into the Nebula Horizon dashboard you'll be able to find your OpenStack instance in the the [Instances list](https://nebula.ncsa.illinois.edu/dashboard/project/instances/) and your key pair in the [Key Pairs tab](https://nebula.ncsa.illinois.edu/dashboard/project/access_and_security/?tab=access_security_tabs__keypairs_tab).
+Your Vagrant machine is provisioned on Nebula's OpenStack cloud through the OpenStack API. Your Nebula OpenStack instance will be named `{VAGRANT_MACHINE}-{USERNAME}` for example `el7-user`. The [vagrant-openstack-provider](https://github.com/ggiamarchi/vagrant-openstack-provider) will create and associate a SSH key pair for your Vagrant machine. If you log into the Nebula Horizon dashboard you'll be able to find your OpenStack instance in the the [Instances list](https://nebula.ncsa.illinois.edu/dashboard/project/instances/) and your key pair in the [Key Pairs tab](https://nebula.ncsa.illinois.edu/dashboard/project/access_and_security/?tab=access_security_tabs__keypairs_tab).
 
 Your exact machine configuration can be changed through editing the `Vagrantfile`, using the Nebula Horizon dashboard or using the OpenStack API.
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,27 @@ A vagrant configuration backed by NCSA's nebula.
 Using vagrant
 -------------
 
-Clone this repo. Get your LSST-openrc.sh from [nebula horizon](https://nebula.ncsa.illinois.edu/dashboard/auth/login/?next=/dashboard/) and source it. Run `vagrant up --provider=openstack` command.
+Clone this repo. Get your LSST-openrc.sh from [nebula horizon](https://nebula.ncsa.illinois.edu/dashboard/auth/login/?next=/dashboard/) and source it. Run `vagrant up el7` command.
 
 ```bash
 source /path/to/LSST-openrc.sh
-# ... put in nebula password
-vagrant up --provider=openstack
+# ... put in your nebula password
+cd /path/to/vagrant-nebula
+vagrant up el7
+```
+
+Time outs and errors can be expected while vagrant attempts to make initial contact with the new nebula machine.
+
+```
+ssh: connect to host 141.142.209.11 port 22: Operation timed out
+Permission denied (publickey,gssapi-keyex,gssapi-with-mic).
+```
+
+SSH to the instance
+-------------------
+
+To ssh to the vagrant machine (nebulua instance) use the command:
+
+```bash
+vagrant ssh el7
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 vagrant-nebula
 ==============
 
-A Vagrant configuration backed by NCSA's Nebula OpenStack cloud.
+A robust Vagrant configuration backed by NCSA's Nebula OpenStack cloud to provide the [LSST Software Stack](http://ls.st/ug).
 
 Getting Nebula Credentials
 --------------------------
 
-You must have the appropriate credentials if you want to use Vagrant to make queries against the nebula OpenStack cloud. By far, the easiest way to obtain authentication credentials is to use [Nebula Horizon dashboard](https://nebula.ncsa.illinois.edu/dashboard/project/access_and_security/). Click the API Access tab to display two buttons and click on the Download OpenStack RC File button. This will generate a file that you can `source` in your shell to populate the environment variables that Vagrant require to know where nebula's service endpoints and authentication information are. In the case of the LSST project, the file will be called `LSST-openrc.sh`.
+You must have the appropriate credentials if you want to use Vagrant to make queries against the nebula OpenStack cloud. By far, the easiest way to obtain authentication credentials is to use the [Nebula Horizon dashboard](https://nebula.ncsa.illinois.edu):
+
+1. Open the Access and Security page of the [Nebula Horizon dashboard](https://nebula.ncsa.illinois.edu).
+2. Click the API Access tab
+3. Click on the Download OpenStack RC File button.
+
+This will generate a file that you can source in your shell to populate the environment variables that Vagrant require to know where Nebula's service endpoints and authentication information are. In the case of the LSST project, the file will be called LSST-openrc.sh.
 
 ```bash
 source /path/to/LSST-openrc.sh
@@ -27,15 +33,16 @@ brew install caskroom/cask/brew-cask
 brew cask install vagrant
 ```
 
-Using Vagrant
--------------
+Create your Vagrant machine
+---------------------------
 
-Vagrant-nebula requires Nebula OpenStack credentials. Please see the Getting Credentials section above.
+Vagrant-nebula requires Nebula OpenStack credentials and Vagrant. Please see the Getting Nebula Credentials and Getting Vagrant sections above.
 
-Clone this repo. `cd` into the directory. Run the `vagrant up el7` command to create the Vagrant machine (Nebula instance).
+To get started, clone the repo, `cd` into the directory and execute the `vagrant up el7` command.
 
 ```bash
-cd /path/to/vagrant-nebula
+git clone https://github.com/lsst-sqre/vagrant-nebula.git
+cd vagrant-nebula
 vagrant up el7
 ```
 
@@ -46,14 +53,38 @@ ssh: connect to host 141.142.209.11 port 22: Operation timed out
 Permission denied (publickey,gssapi-keyex,gssapi-with-mic).
 ```
 
-SSH to the instance
--------------------
+SSH to your Vagrant machine
+---------------------------
 
-To ssh to the Vagrant machine (Nebula instance) use the command:
+By default the [vagrant-openstack-provider](https://github.com/ggiamarchi/vagrant-openstack-provider) will provision and associate an SSH key-pair. To ssh to the Vagrant machine (Nebula instance) use the command:
 
 ```bash
 vagrant ssh el7
 ```
+
+Destroy your Vagrant machine
+----------------------------
+
+Your Vagrant machine is provisioned through the Nebula OpenStack cloud. Resources are limited so it's important that you release those resources when you are not using them. To terminate, or destroy your Vagrant machine use the `vagrant destroy el7`.
+
+```bash
+vagrant destroy el7
+```
+
+Available Vagrant Machines
+--------------------------
+
+By default this Vagrant configuration provides stable [LSST Software Stack](http://ls.st/ug) builds for CentOS 6 and CentOS 7. The following Vagrant machines are available:
+
+* `el6` The current CentOS 6 LSST Software Stack build.
+* `el7` The current CentOS 7 LSST Software Stack build.
+
+Internals
+---------
+
+Your Vagrant machine is provisioned on Nebula's OpenStack cloud through the OpenStack API. Your machine will be named `el7-user` where user is your username when you run the `vagrant` command. The [vagrant-openstack-provider](https://github.com/ggiamarchi/vagrant-openstack-provider) will create and associate an SSH key-pair for your Vagrant machine. If you log into the Nebula Horizon dashboard you'll be able to find your OpenStack instance in the the [Instances list](https://nebula.ncsa.illinois.edu/dashboard/project/instances/) and your key pair in the [Key Pairs tab](https://nebula.ncsa.illinois.edu/dashboard/project/access_and_security/?tab=access_security_tabs__keypairs_tab).
+
+Your exact machine configuration can be changed through editing the `Vagrantfile`, using the Nebula Horizon dashboard or using the OpenStack API.
 
 More Resources
 --------------
@@ -63,6 +94,8 @@ https://www.vagrantup.com/ - The Vagrant homepage.
 https://nebula.ncsa.illinois.edu - The NCSA Nebula OpenStack Horizon dashboard.
 
 https://github.com/ggiamarchi/vagrant-openstack-provider - The Vagrant plugin that vagrant-nebula uses.
+
+http://ls.st/ug - LSST Software Stack documentation.
 
 https://github.com/lsst-sqre/asteroid - Use libcloud to interact with Nebula.
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,27 @@ A vagrant configuration backed by NCSA's nebula.
 Using vagrant
 -------------
 
-Clone this repo. Get your LSST-openrc.sh from [nebula horizon](https://nebula.ncsa.illinois.edu/dashboard/auth/login/?next=/dashboard/) and source it. Run `vagrant up --provider=openstack` command.
+Clone this repo. Get your LSST-openrc.sh from [nebula horizon](https://nebula.ncsa.illinois.edu/dashboard/auth/login/?next=/dashboard/) and source it. Run `vagrant up el7` command to create the vagrant machine (nebula instance).
 
 ```bash
 source /path/to/LSST-openrc.sh
-# ... put in nebula password
-vagrant up --provider=openstack
+# ... put in your nebula password
+cd /path/to/vagrant-nebula
+vagrant up el7
+```
+
+Time outs and errors can be expected while vagrant attempts to make initial contact with the new machine.
+
+```
+ssh: connect to host 141.142.209.11 port 22: Operation timed out
+Permission denied (publickey,gssapi-keyex,gssapi-with-mic).
+```
+
+SSH to the instance
+-------------------
+
+To ssh to the vagrant machine (nebulua instance) use the command:
+
+```bash
+vagrant ssh el7
 ```

--- a/README.md
+++ b/README.md
@@ -1,31 +1,45 @@
 vagrant-nebula
 ==============
 
-A vagrant configuration backed by NCSA's nebula OpenStack cloud.
+A Vagrant configuration backed by NCSA's Nebula OpenStack cloud.
 
-Getting Credentials
--------------------
+Getting Nebula Credentials
+--------------------------
 
-You must have the appropriate credentials if you want to use Vagrant to make queries against the nebula OpenStack cloud. By far, the easiest way to obtain authentication credentials is to use [nebula horizon dashboard](https://nebula.ncsa.illinois.edu/dashboard/project/access_and_security/). Click the API Access tab to display two buttons and click on the Download OpenStack RC File button. This will generate a file that you can `source` in your shell to populate the environment variables that Vagrant require to know where nebula's service endpoints and authentication information are. In the case of the LSST project, the file will be called `LSST-openrc.sh`.
+You must have the appropriate credentials if you want to use Vagrant to make queries against the nebula OpenStack cloud. By far, the easiest way to obtain authentication credentials is to use [Nebula Horizon dashboard](https://nebula.ncsa.illinois.edu/dashboard/project/access_and_security/). Click the API Access tab to display two buttons and click on the Download OpenStack RC File button. This will generate a file that you can `source` in your shell to populate the environment variables that Vagrant require to know where nebula's service endpoints and authentication information are. In the case of the LSST project, the file will be called `LSST-openrc.sh`.
 
 ```bash
 source /path/to/LSST-openrc.sh
 # ... put in your nebula password
 ```
 
-Using vagrant
+Getting Vagrant
+---------------
+
+[Download and install Vagrant](https://www.vagrantup.com/downloads.html) for your platform.
+
+If you are using [Homebrew](http://brew.sh/) you may use the related [Cask](https://github.com/caskroom/homebrew-cask).
+
+```bash
+# Install cask, if it's not already installed.
+brew install caskroom/cask/brew-cask
+# Install the Vagrant cask.
+brew cask install vagrant
+```
+
+Using Vagrant
 -------------
 
-Vagrant-nebula requires OpenStack nebula credentials. Please see the Getting Credentials section above.
+Vagrant-nebula requires Nebula OpenStack credentials. Please see the Getting Credentials section above.
 
-Clone this repo. `cd` into the directory. Run the `vagrant up el7` command to create the vagrant machine (nebula instance).
+Clone this repo. `cd` into the directory. Run the `vagrant up el7` command to create the Vagrant machine (Nebula instance).
 
 ```bash
 cd /path/to/vagrant-nebula
 vagrant up el7
 ```
 
-Time outs and errors can be expected while vagrant attempts to make initial contact with the new machine.
+Time outs and errors can be expected while `vagrant` attempts to make initial contact with the new machine.
 
 ```
 ssh: connect to host 141.142.209.11 port 22: Operation timed out
@@ -35,7 +49,7 @@ Permission denied (publickey,gssapi-keyex,gssapi-with-mic).
 SSH to the instance
 -------------------
 
-To ssh to the vagrant machine (nebulua instance) use the command:
+To ssh to the Vagrant machine (Nebula instance) use the command:
 
 ```bash
 vagrant ssh el7
@@ -44,8 +58,12 @@ vagrant ssh el7
 More Resources
 --------------
 
-https://github.com/ggiamarchi/vagrant-openstack-provider - The vagrant plugin that vagrant-nebula uses.
+https://www.vagrantup.com/ - The Vagrant homepage.
 
-https://github.com/lsst-sqre/asteroid - Use libcloud to interact with nebula.
+https://nebula.ncsa.illinois.edu - The NCSA Nebula OpenStack Horizon dashboard.
+
+https://github.com/ggiamarchi/vagrant-openstack-provider - The Vagrant plugin that vagrant-nebula uses.
+
+https://github.com/lsst-sqre/asteroid - Use libcloud to interact with Nebula.
 
 https://github.com/openstack/python-openstackclient - The OpenStack command-line client.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+vagrant-nebula
+==============
+
+A vagrant configuration backed by NCSA's nebula.
+
+Using vagrant
+-------------
+
+Clone this repo. Get your LSST-openrc.sh from [nebula horizon](https://nebula.ncsa.illinois.edu/dashboard/auth/login/?next=/dashboard/)
+
+```bash
+source /path/to/LSST-openrc.sh
+# ... put in nebula password
+cd vagrant-nebula
+vagrant up --provider=openstack
+```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,32 @@
+required_plugins = %w{
+  vagrant-openstack-provider
+}
+
+plugins_to_install = required_plugins.select { |plugin| not Vagrant.has_plugin? plugin }
+if not plugins_to_install.empty?
+  puts "Installing plugins: #{plugins_to_install.join(' ')}"
+  system "vagrant plugin install #{plugins_to_install.join(' ')}"
+  exec "vagrant #{ARGV.join(' ')}"
+end
+
+require 'vagrant-openstack-provider'
+
+Vagrant.configure('2') do |config|
+
+  config.vm.define 'vagrant-nebula', primary: true do |define|
+    define.vm.box       = 'openstack-vagrant-nebula'
+    define.ssh.username = 'ubuntu'
+
+    define.vm.provider :openstack do |os|
+      os.openstack_auth_url = ENV['OS_AUTH_URL']
+      os.username           = ENV['OS_USERNAME']
+      os.password           = ENV['OS_PASSWORD']
+      os.tenant_name        = ENV['OS_PROJECT_NAME']
+      os.flavor             = ENV['OS_FLAVOR_NAME'] || 'm1.medium'
+      os.image              = ENV['OS_IMAGE_NAME'] || 'b1f4bb91-13fb-4e73-b697-3c0ab23d17ec'
+      os.floating_ip_pool   = 'ext-net'
+      os.security_groups    = ['default', 'remote SSH', 'remote mosh']
+      os.networks           = ['fc77a88d-a9fb-47bb-a65d-39d1be7a7174'] # LSST-net
+    end
+  end
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,21 +12,37 @@ end
 require 'vagrant-openstack-provider'
 
 Vagrant.configure('2') do |config|
+  config.ssh.username = 'vagrant'
 
-  config.vm.define 'vagrant-nebula', primary: true do |define|
-    define.vm.box       = 'openstack-vagrant-nebula'
-    define.ssh.username = 'ubuntu'
-
-    define.vm.provider :openstack do |os|
-      os.openstack_auth_url = ENV['OS_AUTH_URL']
-      os.username           = ENV['OS_USERNAME']
-      os.password           = ENV['OS_PASSWORD']
-      os.tenant_name        = ENV['OS_PROJECT_NAME']
-      os.flavor             = ENV['OS_FLAVOR_NAME'] || 'm1.medium'
-      os.image              = ENV['OS_IMAGE_NAME'] || 'b1f4bb91-13fb-4e73-b697-3c0ab23d17ec'
-      os.floating_ip_pool   = 'ext-net'
-      os.security_groups    = ['default', 'remote SSH', 'remote mosh']
-      os.networks           = ['fc77a88d-a9fb-47bb-a65d-39d1be7a7174'] # LSST-net
+  config.vm.define 'el6' do |define|
+    define.vm.provider :openstack do |provider, override|
+      provider.image = 'centos-6-stack-w_2015_45-1447095131'
+      provider.server_name = "el6-#{ENV['USER']}"
     end
+  end
+
+  config.vm.define 'el7' do |define|
+    define.vm.provider :openstack do |provider, override|
+      provider.image = 'centos-7-stack-w_2015_45-1447100091'
+      provider.server_name = "el7-#{ENV['USER']}"
+    end
+  end
+
+  config.vm.provider :openstack do |os,override|
+    os.sync_method        = 'none'
+    os.user_data          = <<-EOS
+#cloud-config
+system_info:
+  default_user:
+    name: vagrant
+    EOS
+    os.username           = ENV['OS_USERNAME']
+    os.password           = ENV['OS_PASSWORD']
+    os.tenant_name        = ENV['OS_PROJECT_NAME']
+    os.openstack_auth_url = ENV['OS_AUTH_URL']
+    os.flavor             = 'm1.xlarge'
+    os.floating_ip_pool   = 'ext-net'
+    os.security_groups    = ['default', 'remote SSH']
+    os.networks           = ['fc77a88d-a9fb-47bb-a65d-39d1be7a7174']
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,14 +16,14 @@ Vagrant.configure('2') do |config|
 
   config.vm.define 'el6' do |define|
     define.vm.provider :openstack do |provider, override|
-      provider.image = 'centos-6-stack-w_2015_45-1447095131'
+      provider.image = 'a4bd6e75-1ef5-49ca-a71d-15f379626552'
       provider.server_name = "el6-#{ENV['USER']}"
     end
   end
 
   config.vm.define 'el7' do |define|
     define.vm.provider :openstack do |provider, override|
-      provider.image = 'centos-7-stack-w_2015_45-1447100091'
+      provider.image = '3a26f5a2-856a-406f-9ea1-2aa58f230a62'
       provider.server_name = "el7-#{ENV['USER']}"
     end
   end


### PR DESCRIPTION
A Vagrant configuration for NCSA's nebula OpenStack cloud + lsstsw.
- Uses @jhoblitt's lsstsw snapshots.
- Supports el6 and el7 machines.
- Improved README.md documentation.
- Added references to other resources.

If anyone else has ideas on how to improve it, please contribute them.
